### PR TITLE
readFileSync, writeFileSync breaking change since rootDir for the wor…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,17 @@
 {
-  "name": "@razroo/razzle",
-  "version": "1.0.0",
+  "name": "@codemorph/core",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@razroo/razzle",
-      "version": "1.0.0",
+      "name": "@codemorph/core",
+      "version": "1.0.4",
       "license": "RAZROO",
+      "workspaces": [
+        "angular",
+        "src/rz/angular"
+      ],
       "dependencies": {
         "@ctrl/tinycolor": "^3.4.1",
         "chalk": "4.1.0",
@@ -72,6 +76,11 @@
         "typescript": "^4.0.3",
         "yargs-parser": "20.0.0"
       }
+    },
+    "angular": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "ISC"
     },
     "node_modules/@ampproject/remapping": {
       "version": "1.0.1",
@@ -4967,6 +4976,10 @@
           "optional": true
         }
       }
+    },
+    "node_modules/angular": {
+      "resolved": "src/rz/angular",
+      "link": true
     },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
@@ -17902,6 +17915,10 @@
       "dependencies": {
         "tslib": "^2.3.0"
       }
+    },
+    "src/rz/angular": {
+      "version": "1.0.0",
+      "license": "ISC"
     }
   },
   "dependencies": {
@@ -21541,6 +21558,9 @@
       "requires": {
         "ajv": "^8.0.0"
       }
+    },
+    "angular": {
+      "version": "file:src/rz/angular"
     },
     "ansi-colors": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@codemorph/core",
+  "workspaces": [
+    "src/rz/angular"
+  ],
   "version": "1.0.4",
   "description": "Code Morph is an extensible, easy to understand, easy contribute, easy to use Codemod library.",
   "main": "./dist/index.js",

--- a/src/rz/angular/effects/component/component-effects.spec.ts
+++ b/src/rz/angular/effects/component/component-effects.spec.ts
@@ -4,12 +4,12 @@ import { effects, Parameters } from "../../../morph";
 
 describe('Angular Component Effects', () => {
   afterEach(() => {
-    const moduleOriginal = readFileSync('src/rz/angular/effects/component/snapshots/module-original.ts.snap').toString();
-    writeFileSync('src/rz/angular/effects/component/index.ts', '');
-    writeFileSync('src/rz/angular/effects/component/sample.module.ts', moduleOriginal);
+    const moduleOriginal = readFileSync('effects/component/snapshots/module-original.ts.snap').toString();
+    writeFileSync('effects/component/index.ts', '');
+    writeFileSync('effects/component/sample.module.ts', moduleOriginal);
   });
   it('should update the closest app module file with an ngmodule export, declaration, import component, and export via optional type', () => {
-    const mockFilePath = 'src/rz/angular/effects/component/sample.component.ts';
+    const mockFilePath = 'effects/component/sample.component.ts';
     const parameters: Parameters = {
       className: 'Sample'
     };
@@ -24,12 +24,12 @@ describe('Angular Component Effects', () => {
     }
     effects(mockFilePath, mockTemplateInputParameter, 'angular', JSON.stringify(parameters));
 
-    const indexResult = readFileSync('src/rz/angular/effects/component/index.ts').toString();
-    const indexExpected = readFileSync('src/rz/angular/effects/component/snapshots/index-output.ts.snap').toString();
+    const indexResult = readFileSync('effects/component/index.ts').toString();
+    const indexExpected = readFileSync('effects/component/snapshots/index-output.ts.snap').toString();
     expect(indexResult).toEqual(indexExpected);
 
-    const moduleResult = readFileSync('src/rz/angular/effects/component/sample.module.ts').toString();
-    const moduleExpected = readFileSync('src/rz/angular/effects/component/snapshots/module-output.ts.snap').toString();
+    const moduleResult = readFileSync('effects/component/sample.module.ts').toString();
+    const moduleExpected = readFileSync('effects/component/snapshots/module-output.ts.snap').toString();
     expect(moduleResult).toEqual(moduleExpected);
   })
 });

--- a/src/rz/angular/jest.config.js
+++ b/src/rz/angular/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest'
+  },
+  globals: {
+    'ts-jest': {
+      diagnostics: false,
+      useESM: true
+    }
+  },
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(t|j)s$',
+  moduleFileExtensions: ['ts', 'js', 'json', 'node'],
+};

--- a/src/rz/angular/package.json
+++ b/src/rz/angular/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@codemorph/angular",
+  "workspaces": [
+    "src/rz/angular"
+  ],
+  "version": "0.0.1",
+  "description": "Code Morph is an extensible, easy to understand, easy contribute, easy to use Codemod library.",
+  "main": "../../../../dist/index.js",
+  "types": "../../../../dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "format": "prettier --write \"src/**/*.(js|ts)\"",
+    "lint": "eslint src --ext .js,.ts",
+    "lint:fix": "eslint src --fix --ext .js,.ts",
+    "test": "jest --config jest.config.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/razroo/razzle"
+  },
+  "keywords": [
+    "razroo",
+    "codemod",
+    "angular"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "Razroo",
+  "license": "RAZROO",
+  "bugs": {
+    "url": "https://github.com/razroo/razzle/issues"
+  },
+  "homepage": "https://github.com/razroo/razzle#readme"
+}


### PR DESCRIPTION
file path in test files while reading/writing has to be changed to the workspace dir in order for the test file to run tests for the workspace.  

when running tests for the workspace using,

 `npm run test -ws`

FileNotFound error for the read/write files in the test files. like, 
`ENOENT: no such file or directory, open 'src/rz/angular/effects/interface/index.ts'`

For example: 
`src/rz/angular/effects/directive/user.directive.ts`

has to be changed into 

`effects/directive/user.directive.ts `. 
since rootDir for the workspace file is rz/angular not src/rz/angular