### PR TITLE
ZETA-6356: Add sister effect groundwork.

### DIFF
--- a/src/rz/angular/effects/component/component-effects.spec.ts
+++ b/src/rz/angular/effects/component/component-effects.spec.ts
@@ -1,9 +1,10 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { TemplateInputParameter } from '../../../utils/interfaces/template-parameters';
 import { effects, Parameters } from "../../../morph";
-import { fileToAddClassToDeclarationsAndImports } from './component-effects';
+import { componentEffects, fileToAddClassToDeclarationsAndImports } from './component-effects';
 import { filesToAffect } from '../../../morph/morph';
 import { AngularTypeNames } from '../../types/types';
+import { EditFileEffect } from '../../../morph/interfaces/morph.interface';
 
 describe('Angular Component Effects', () => {
   afterEach(() => {
@@ -51,5 +52,17 @@ describe('Angular Component Effects', () => {
     ];
     const fileToModify = filesToAffect(mockFilePath, fileTree, mockParameter, 'angular');
     expect(fileToModify).toEqual('path/to/another/hello.module.ts');
+  });
+
+  it('should trigger component effects', () => {
+    const mockFileEffects: EditFileEffect[] = [{
+      filePath: 'path/to/another/hello.module.ts',
+      content: ''
+    }];
+    const result = componentEffects(mockFileEffects);
+    expect(result).toEqual([{
+      content: "xyz",
+      filePath: "path/to/another/hello.module.ts"
+    }]);
   });
 });

--- a/src/rz/angular/effects/component/component-effects.ts
+++ b/src/rz/angular/effects/component/component-effects.ts
@@ -1,4 +1,4 @@
-import { EditInput } from '../../../morph/interfaces/morph.interface';
+import { EditFileEffect, EditInput } from '../../../morph/interfaces/morph.interface';
 import { readFileSync, writeFileSync } from 'fs';
 import { findClosestModuleFile } from "../../../utils";
 import { createRelativePath, exportTsFiles, isTsFile } from "../../../utils/add-export";
@@ -13,6 +13,18 @@ export function fileToAddClassToDeclarationsAndImports(filePathWithName: string,
   } else {
     return '';
   }
+}
+
+export function componentEffects(fileEffects: EditFileEffect[]): EditFileEffect[] {
+  for(const fileEffect of fileEffects) {
+    const filePath = fileEffect.filePath;
+    if(filePath.includes('module.ts')) {
+      fileEffect.content = 'xyz';
+      console.log('filePath');
+      console.log(filePath);
+    }
+  }
+  return fileEffects;
 }
 
 export function addClassToDeclarationsAndImports(filePathWithName: string, className: string, optionalTypes: AngularOptionalType[]): void {

--- a/src/rz/morph/interfaces/morph.interface.ts
+++ b/src/rz/morph/interfaces/morph.interface.ts
@@ -24,3 +24,8 @@ export interface EditFile {
   parameters?: any;
   bodyText?: string;
 }
+
+export interface EditFileEffect {
+  filePath: string; 
+  content: string;
+}


### PR DESCRIPTION
Adds groundwork needed, so we can have effects within a backend setting using file strings only. 

1. In short, it used the name of the file itself, to determine the type of file 
2. If need be, we can use the content as an identifier of the type of file as well 

User just needs to pass in files to effects and good to go 