### PR TITLE
[ZETA-6359]: That's a wrap - Ship it - standaloneEffects 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export { getVersionAndNameString, determineType, determineFilePathParameter, rea
     getAllDirectoriesFromVsCodeFolder, determineLanguagesUsed, replaceCodeModEditsTemplateVariables } from './rz/utils';
 
 // export typescript related edits
-export { EditInput, EditFile, morphCode, effects, communityPaths, types } from './rz/morph';
+export { EditInput, EditFile, morphCode, effects, standaloneEffects, filesToAffect, communityPaths, types } from './rz/morph';
 
 // export typescript related edits
 export { getCodeModParams, getCodeModOptions } from './rz/params';

--- a/src/rz/angular/angular-effects.ts
+++ b/src/rz/angular/angular-effects.ts
@@ -1,5 +1,6 @@
 import { Parameters } from "../morph";
-import { addClassToDeclarationsAndImports, fileToAddClassToDeclarationsAndImports } from "./effects/component/component-effects";
+import { EditFileEffect } from "../morph/interfaces/morph.interface";
+import { addClassToDeclarationsAndImports, componentEffects, fileToAddClassToDeclarationsAndImports } from "./effects/component/component-effects";
 import { exportDirectiveFile } from "./effects/directive/directive";
 import { exportGraphqlFile } from "./effects/graphql/graphql";
 import { exportInterfaceFile } from "./effects/interface/interface";
@@ -16,6 +17,15 @@ export function angularFilesToAffect(filePathWithName: string, fileTree: string[
       return fileToAddClassToDeclarationsAndImports(filePathWithName, fileTree, optionalTypes);
     default:
       return ''
+  }
+}
+
+export function angularStandaloneEffects(type: AngularTypeNames, fileEffects: EditFileEffect[]): EditFileEffect[] {
+  switch(type) {
+    case AngularTypeNames.Component:
+      return componentEffects(fileEffects);
+    default:
+      return [];
   }
 }
 

--- a/src/rz/angular/effects/component/component-effects.spec.ts
+++ b/src/rz/angular/effects/component/component-effects.spec.ts
@@ -67,7 +67,7 @@ describe('Angular Component Effects', () => {
       export class CommonUiModule {}
       `
     }];
-    const result = componentEffects(mockFilePath, mockFileEffects);
+    const result = componentEffects(mockFileEffects);
     const moduleContent = `import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HelloComponent } from "./src/hello.component";
@@ -81,6 +81,7 @@ export class CommonUiModule { }
 `;
     expect(result).toEqual([{
       content: moduleContent,
+      originFilePath: "path/to/another/src/hello.component.ts",
       filePath: "path/to/another/hello.module.ts"
     }]);
   });

--- a/src/rz/angular/effects/component/component-effects.spec.ts
+++ b/src/rz/angular/effects/component/component-effects.spec.ts
@@ -55,11 +55,19 @@ describe('Angular Component Effects', () => {
   });
 
   it('should trigger component effects', () => {
+    const mockFilePath = 'path/to/another/src/hello.component.ts';
     const mockFileEffects: EditFileEffect[] = [{
       filePath: 'path/to/another/hello.module.ts',
-      content: ''
+      content: `import { NgModule } from '@angular/core';
+      import { CommonModule } from '@angular/common';
+      
+      @NgModule({
+        imports: [CommonModule],
+      })
+      export class CommonUiModule {}
+      `
     }];
-    const result = componentEffects(mockFileEffects);
+    const result = componentEffects(mockFilePath, mockFileEffects);
     expect(result).toEqual([{
       content: "xyz",
       filePath: "path/to/another/hello.module.ts"

--- a/src/rz/angular/effects/component/component-effects.spec.ts
+++ b/src/rz/angular/effects/component/component-effects.spec.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { TemplateInputParameter } from '../../../utils/interfaces/template-parameters';
 import { effects, Parameters } from "../../../morph";
 import { componentEffects, fileToAddClassToDeclarationsAndImports } from './component-effects';
-import { filesToAffect } from '../../../morph/morph';
+import { filesToAffect, standaloneEffects } from '../../../morph/morph';
 import { AngularTypeNames } from '../../types/types';
 import { EditFileEffect } from '../../../morph/interfaces/morph.interface';
 
@@ -54,7 +54,11 @@ describe('Angular Component Effects', () => {
     expect(fileToModify).toEqual('path/to/another/hello.module.ts');
   });
 
-  it('should trigger component effects', () => {
+  it('should trigger component standalone effects codemorph', () => {
+    const programmingLanguage = 'angular';
+    const mockParameter = {
+      type: AngularTypeNames.Component
+    } as any;
     const mockFileEffects: EditFileEffect[] = [{
       filePath: 'path/to/another/hello.module.ts',
       originFilePath: 'path/to/another/src/hello.component.ts',
@@ -67,7 +71,7 @@ describe('Angular Component Effects', () => {
       export class CommonUiModule {}
       `
     }];
-    const result = componentEffects(mockFileEffects);
+    const result = standaloneEffects(programmingLanguage, mockParameter, mockFileEffects);
     const moduleContent = `import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HelloComponent } from "./src/hello.component";

--- a/src/rz/angular/effects/component/component-effects.spec.ts
+++ b/src/rz/angular/effects/component/component-effects.spec.ts
@@ -55,9 +55,9 @@ describe('Angular Component Effects', () => {
   });
 
   it('should trigger component effects', () => {
-    const mockFilePath = 'path/to/another/src/hello.component.ts';
     const mockFileEffects: EditFileEffect[] = [{
       filePath: 'path/to/another/hello.module.ts',
+      originFilePath: 'path/to/another/src/hello.component.ts',
       content: `import { NgModule } from '@angular/core';
       import { CommonModule } from '@angular/common';
       

--- a/src/rz/angular/effects/component/component-effects.spec.ts
+++ b/src/rz/angular/effects/component/component-effects.spec.ts
@@ -68,8 +68,19 @@ describe('Angular Component Effects', () => {
       `
     }];
     const result = componentEffects(mockFilePath, mockFileEffects);
+    const moduleContent = `import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HelloComponent } from "./src/hello.component";
+
+@NgModule({
+  imports: [CommonModule],
+  exports: [HelloComponent],
+  declarations: [HelloComponent]
+})
+export class CommonUiModule { }
+`;
     expect(result).toEqual([{
-      content: "xyz",
+      content: moduleContent,
       filePath: "path/to/another/hello.module.ts"
     }]);
   });

--- a/src/rz/angular/effects/component/component-effects.ts
+++ b/src/rz/angular/effects/component/component-effects.ts
@@ -15,14 +15,15 @@ export function fileToAddClassToDeclarationsAndImports(filePathWithName: string,
   }
 }
 
-export function componentEffects(filePathWithName: string, fileEffects: EditFileEffect[]): EditFileEffect[] {
+export function componentEffects(fileEffects: EditFileEffect[]): EditFileEffect[] {
   for(const fileEffect of fileEffects) {
     const filePath = fileEffect.filePath;
+    const originFilePath = fileEffect.originFilePath;
     if(filePath.includes('module.ts')) {
-      const componentFileName = filePathWithName.split('/').pop();
+      const componentFileName = originFilePath.split('/').pop();
       const componentName = (componentFileName as any).split('.')[0];
       const componentClassName = `${names(componentName).className}Component`;
-      const importPath = createRelativePath(filePathWithName, filePath);
+      const importPath = createRelativePath(originFilePath, filePath);
       const fileName = filePath.split('/').pop();
       const fileToBeAddedTo = fileEffect.content;
       const editInput: EditInput = {

--- a/src/rz/angular/effects/component/component-effects.ts
+++ b/src/rz/angular/effects/component/component-effects.ts
@@ -15,11 +15,39 @@ export function fileToAddClassToDeclarationsAndImports(filePathWithName: string,
   }
 }
 
-export function componentEffects(fileEffects: EditFileEffect[]): EditFileEffect[] {
+export function componentEffects(filePathWithName: string, fileEffects: EditFileEffect[]): EditFileEffect[] {
   for(const fileEffect of fileEffects) {
     const filePath = fileEffect.filePath;
     if(filePath.includes('module.ts')) {
-      fileEffect.content = 'xyz';
+      const componentFileName = filePathWithName.split('/').pop();
+      const componentName = (componentFileName as any).split('.')[0];
+      const componentClassName = `${names(componentName).className}Component`;
+      const importPath = createRelativePath(filePathWithName, filePath);
+      const fileName = filePath.split('/').pop();
+      const fileToBeAddedTo = fileEffect.content;
+      const editInput: EditInput = {
+        fileType: 'ts',
+        fileName: fileName,
+        filePath: filePath,
+        fileToBeAddedTo: fileToBeAddedTo,
+        edits: [
+          {
+            nodeType: 'addNgModuleExport',
+            codeBlock: componentClassName,
+          },
+          {
+            nodeType: 'addNgModuleDeclaration',
+            codeBlock: componentClassName,
+          },
+          {
+            nodeType: 'import',
+            codeBlock: `{ ${componentClassName} }`,
+            path: importPath,
+          }
+        ]
+      };
+      const updatedFileToBeAddedTo = morphTypescript(editInput);
+      fileEffect.content = updatedFileToBeAddedTo;
       console.log('filePath');
       console.log(filePath);
     }

--- a/src/rz/morph/index.ts
+++ b/src/rz/morph/index.ts
@@ -1,3 +1,3 @@
-export { morphCode, filesToAffect, effects, Parameters, types } from "./morph";
+export { morphCode, filesToAffect, effects, standaloneEffects, Parameters, types } from "./morph";
 export { EditFile, EditInput} from "./interfaces/morph.interface";
 export { communityPaths, supportedCommunityPaths } from "./community-paths/community-paths";

--- a/src/rz/morph/interfaces/morph.interface.ts
+++ b/src/rz/morph/interfaces/morph.interface.ts
@@ -28,4 +28,5 @@ export interface EditFile {
 export interface EditFileEffect {
   filePath: string; 
   content: string;
+  originFilePath: string;
 }

--- a/src/rz/morph/morph.ts
+++ b/src/rz/morph/morph.ts
@@ -60,12 +60,15 @@ export function effects(filePathWithName: string, parameter: TemplateInputParame
   }
 }
 
+// 2.0 effects api 
+// allows effects to work in any environment e.g. backend, system, frontend thus standalone
 export function standaloneEffects(programmingLanguage: string, parameter: TemplateInputParameter, fileEffects: EditFileEffect[]): EditFileEffect[] {
   switch(programmingLanguage) {
     case 'angular':
       return angularStandaloneEffects((parameter.type) as AngularTypeNames, fileEffects)
     default:
       return []  
+  }
 }
 
 export function types(programmingLanguage: string): any[] {

--- a/src/rz/morph/morph.ts
+++ b/src/rz/morph/morph.ts
@@ -55,7 +55,7 @@ export function effects(filePathWithName: string, parameter: TemplateInputParame
   const parsedParemeters: Parameters = typeof parameters === 'string' ? JSON.parse(parameters) : parameters;
 
   switch(programmingLanguage) {
-    case 'angular':
+    case CommunityPaths.Angular:
       angularEffects(filePathWithName, (parameter.type) as AngularTypeNames, parsedParemeters, (parameter.optionalTypes) as any as AngularOptionalType[]);
   }
 }
@@ -64,7 +64,7 @@ export function effects(filePathWithName: string, parameter: TemplateInputParame
 // allows effects to work in any environment e.g. backend, system, frontend thus standalone
 export function standaloneEffects(programmingLanguage: string, parameter: TemplateInputParameter, fileEffects: EditFileEffect[]): EditFileEffect[] {
   switch(programmingLanguage) {
-    case 'angular':
+    case CommunityPaths.Angular:
       return angularStandaloneEffects((parameter.type) as AngularTypeNames, fileEffects)
     default:
       return []  

--- a/src/rz/morph/morph.ts
+++ b/src/rz/morph/morph.ts
@@ -59,6 +59,12 @@ export function effects(filePathWithName: string, parameter: TemplateInputParame
   }
 }
 
+export function standaloneEffects(programmingLanguage: string) {
+  switch(programmingLanguage) {
+    case 'angular':
+      
+}
+
 export function types(programmingLanguage: string): any[] {
   switch(programmingLanguage) {
     case CommunityPaths.Angular: 

--- a/src/rz/morph/morph.ts
+++ b/src/rz/morph/morph.ts
@@ -8,9 +8,10 @@ import { morphTypescript } from '../typescript/morph-typescript';
 import { morphScss } from '../scss/morph-scss';
 import { morphJson } from '../json/json-morph';
 import { EditJsonInput } from '../json/interfaces/json-morph.interface';
-import { angularEffects, angularFilesToAffect } from '../angular/angular-effects';
+import { angularEffects, angularFilesToAffect, angularStandaloneEffects } from '../angular/angular-effects';
 import { reactTypes } from '../react';
 import { TemplateInputParameter } from '../utils/interfaces/template-parameters';
+import { EditFileEffect } from './interfaces/morph.interface';
 
 // takes in singular object and makes all edits to files 
 // used when editing a file
@@ -59,10 +60,12 @@ export function effects(filePathWithName: string, parameter: TemplateInputParame
   }
 }
 
-export function standaloneEffects(programmingLanguage: string) {
+export function standaloneEffects(programmingLanguage: string, parameter: TemplateInputParameter, fileEffects: EditFileEffect[]): EditFileEffect[] {
   switch(programmingLanguage) {
     case 'angular':
-      
+      return angularStandaloneEffects((parameter.type) as AngularTypeNames, fileEffects)
+    default:
+      return []  
 }
 
 export function types(programmingLanguage: string): any[] {

--- a/src/rz/morph/morph.ts
+++ b/src/rz/morph/morph.ts
@@ -47,7 +47,21 @@ export function filesToAffect(filePathWithName: string, fileTree: string[], para
   }
 }
 
+// 2.0 effects api 
 // sister function to "fileToAffect"
+// effects are called whenever a file is generated
+// such as automatically exporting file in closes index ts file
+// type respresents component, guard, pipe etc, which is specific to programming language
+// allows effects to work in any environment e.g. backend, system, frontend thus standalone
+export function standaloneEffects(programmingLanguage: string, parameter: TemplateInputParameter, fileEffects: EditFileEffect[]): EditFileEffect[] {
+  switch(programmingLanguage) {
+    case CommunityPaths.Angular:
+      return angularStandaloneEffects((parameter.type) as AngularTypeNames, fileEffects)
+    default:
+      return []  
+  }
+}
+
 // effects are called whenever a file is generated
 // such as automatically exporting file in closes index ts file
 // type respresents component, guard, pipe etc, which is specific to programming language
@@ -57,17 +71,6 @@ export function effects(filePathWithName: string, parameter: TemplateInputParame
   switch(programmingLanguage) {
     case CommunityPaths.Angular:
       angularEffects(filePathWithName, (parameter.type) as AngularTypeNames, parsedParemeters, (parameter.optionalTypes) as any as AngularOptionalType[]);
-  }
-}
-
-// 2.0 effects api 
-// allows effects to work in any environment e.g. backend, system, frontend thus standalone
-export function standaloneEffects(programmingLanguage: string, parameter: TemplateInputParameter, fileEffects: EditFileEffect[]): EditFileEffect[] {
-  switch(programmingLanguage) {
-    case CommunityPaths.Angular:
-      return angularStandaloneEffects((parameter.type) as AngularTypeNames, fileEffects)
-    default:
-      return []  
   }
 }
 


### PR DESCRIPTION
Works with any environment. E.g. system, browser, or backend. 

Takes in three parameters to work 

```
programmingLanguage: string, parameter: TemplateInputParameter, fileEffects: EditFileEffect[]
```

```
export interface EditFileEffect {
  filePath: string; 
  content: string;
  originFilePath: string;
}
```

Let's go 🚀