### PR TITLE
[ZETA-6580]: Add standalone effects for standalone components

### DIFF
--- a/src/rz/angular/angular-effects.ts
+++ b/src/rz/angular/angular-effects.ts
@@ -8,13 +8,15 @@ import { addEffectToNgModule } from "./effects/ngrx/effects/ngrx-effects";
 import { addFacadeToNgModule } from "./effects/ngrx/facade/ngrx-facade";
 import { addReducerToNgModule } from "./effects/ngrx/reducer/ngrx-reducer";
 import { exportServiceFile } from "./effects/service/service";
-import { exportComponentFile } from "./effects/standalone-component/standalone-component";
-import { AngularType, AngularTypeNames, AngularOptionalType } from "./types/types";
+import { closestIndexFileToImportTo, exportComponentFile } from "./effects/standalone-component/standalone-component";
+import { AngularTypeNames, AngularOptionalType } from "./types/types";
 
 export function angularFilesToAffect(filePathWithName: string, fileTree: string[], type: AngularTypeNames, optionalTypes: AngularOptionalType[]): string[] | NOT_SUPPORTED_TYPE {
   switch(type) {
     case AngularTypeNames.Component:
       return fileToAddClassToDeclarationsAndImports(filePathWithName, fileTree, optionalTypes);
+    case AngularTypeNames.StandaloneComponent:
+      return closestIndexFileToImportTo(filePathWithName, fileTree, optionalTypes);
     default:
       return NOT_SUPPORTED;
   }
@@ -24,6 +26,8 @@ export function angularStandaloneEffects(type: AngularTypeNames, fileEffects: Ed
   switch(type) {
     case AngularTypeNames.Component:
       return componentEffects(fileEffects);
+    case AngularTypeNames.StandaloneComponent:
+      return componentEffects(fileEffects);  
     default:
       return [];
   }

--- a/src/rz/angular/angular-effects.ts
+++ b/src/rz/angular/angular-effects.ts
@@ -8,7 +8,7 @@ import { addEffectToNgModule } from "./effects/ngrx/effects/ngrx-effects";
 import { addFacadeToNgModule } from "./effects/ngrx/facade/ngrx-facade";
 import { addReducerToNgModule } from "./effects/ngrx/reducer/ngrx-reducer";
 import { exportServiceFile } from "./effects/service/service";
-import { closestIndexFileToImportTo, exportComponentFile } from "./effects/standalone-component/standalone-component";
+import { closestIndexFileToImportTo, exportComponentFile, standaloneComponentEffects } from "./effects/standalone-component/standalone-component";
 import { AngularTypeNames, AngularOptionalType } from "./types/types";
 
 export function angularFilesToAffect(filePathWithName: string, fileTree: string[], type: AngularTypeNames, optionalTypes: AngularOptionalType[]): string[] | NOT_SUPPORTED_TYPE {
@@ -27,7 +27,7 @@ export function angularStandaloneEffects(type: AngularTypeNames, fileEffects: Ed
     case AngularTypeNames.Component:
       return componentEffects(fileEffects);
     case AngularTypeNames.StandaloneComponent:
-      return componentEffects(fileEffects);  
+      return standaloneComponentEffects(fileEffects);  
     default:
       return [];
   }

--- a/src/rz/angular/effects/component/component-effects.spec.ts
+++ b/src/rz/angular/effects/component/component-effects.spec.ts
@@ -1,7 +1,6 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { TemplateInputParameter } from '../../../utils/interfaces/template-parameters';
 import { effects, Parameters } from "../../../morph";
-import { componentEffects, fileToAddClassToDeclarationsAndImports } from './component-effects';
 import { filesToAffect, standaloneEffects } from '../../../morph/morph';
 import { AngularTypeNames } from '../../types/types';
 import { EditFileEffect } from '../../../morph/interfaces/morph.interface';

--- a/src/rz/angular/effects/component/component-effects.ts
+++ b/src/rz/angular/effects/component/component-effects.ts
@@ -5,11 +5,11 @@ import { createRelativePath, exportTsFiles, isTsFile } from "../../../utils/add-
 import { morphTypescript } from '../../../typescript/morph-typescript';
 import { GlobalAngularOptionNames, AngularOptionalType } from '../../types/types';
 import { names } from '../../../global-variables';
-import { findClosestModuleFileUsingPaths } from '../../../utils/find-module-file/find-module-file';
+import { findClosestFileMatchUsingPaths } from '../../../utils/find-closest-file/find-closest-file';
 
 export function fileToAddClassToDeclarationsAndImports(filePathWithName: string, fileTree: string[], optionalTypes: AngularOptionalType[]): string[] {
   if(isTsFile(filePathWithName)) {
-    return findClosestModuleFileUsingPaths(filePathWithName, fileTree);
+    return findClosestFileMatchUsingPaths(filePathWithName, fileTree, 'module.ts');
   } else {
     return [];
   }

--- a/src/rz/angular/effects/standalone-component/standalone-component.ts
+++ b/src/rz/angular/effects/standalone-component/standalone-component.ts
@@ -1,7 +1,16 @@
 import { exportTsFiles, isTsFile } from "../../../utils/add-export";
+import { findClosestFileUsingPaths } from "../../../utils/find-closest-file/find-closest-file";
 
 export function exportComponentFile(filePathWithName: string): void {
   if(isTsFile(filePathWithName)) {
     exportTsFiles(filePathWithName);
+  }
+}
+
+export function closestIndexFileToImportTo(filePathWithName: string, fileTree: string[], optionalTypes: AngularOptionalType[]): string[] {
+  if(isTsFile(filePathWithName)) {
+    return findClosestFileUsingPaths(filePathWithName, fileTree, 'index.ts');
+  } else {
+    return [];
   }
 }

--- a/src/rz/angular/effects/standalone-component/standalone-component.ts
+++ b/src/rz/angular/effects/standalone-component/standalone-component.ts
@@ -2,6 +2,7 @@ import { EditFileEffect } from "../../../morph/interfaces/morph.interface";
 import { morphTypescript } from "../../../typescript/morph-typescript";
 import { createRelativePath, exportTsFiles, isTsFile } from "../../../utils/add-export";
 import { findClosestFileUsingPaths } from "../../../utils/find-closest-file/find-closest-file";
+import { AngularOptionalType } from "../../types/types";
 
 export function exportComponentFile(filePathWithName: string): void {
   if(isTsFile(filePathWithName)) {

--- a/src/rz/angular/effects/standalone-component/standalone-component.ts
+++ b/src/rz/angular/effects/standalone-component/standalone-component.ts
@@ -1,4 +1,6 @@
-import { exportTsFiles, isTsFile } from "../../../utils/add-export";
+import { EditFileEffect } from "../../../morph/interfaces/morph.interface";
+import { morphTypescript } from "../../../typescript/morph-typescript";
+import { createRelativePath, exportTsFiles, isTsFile } from "../../../utils/add-export";
 import { findClosestFileUsingPaths } from "../../../utils/find-closest-file/find-closest-file";
 
 export function exportComponentFile(filePathWithName: string): void {
@@ -13,4 +15,30 @@ export function closestIndexFileToImportTo(filePathWithName: string, fileTree: s
   } else {
     return [];
   }
+}
+
+export function standaloneComponentEffects(fileEffects: EditFileEffect[]): EditFileEffect[] {
+  for(const fileEffect of fileEffects) {
+    const filePath = fileEffect.filePath;
+    const originFilePath = fileEffect.originFilePath;
+    if(filePath.includes('index.ts')) {
+      const fileName = filePath.split('/').pop();
+      const fileToBeAddedTo = fileEffect.content;
+      const exportPath = createRelativePath(originFilePath, filePath);
+      const editInput: any = {
+        fileType: 'ts',
+        fileName: fileName,
+        filePath: filePath,
+        fileToBeAddedTo: fileToBeAddedTo,
+        edits: [{
+          nodeType: 'export',
+          codeBlock: '',
+          path: exportPath
+        }]
+      };
+      const updatedFileToBeAddedTo = morphTypescript(editInput);
+      fileEffect.content = updatedFileToBeAddedTo;
+    }
+  }
+  return fileEffects;
 }

--- a/src/rz/angular/effects/standalone-component/standlone-component.spec.ts
+++ b/src/rz/angular/effects/standalone-component/standlone-component.spec.ts
@@ -1,7 +1,8 @@
 import { TemplateInputParameter } from './../../../utils/interfaces/template-parameters';
 import { writeFileSync, readFileSync } from 'fs';
-import { effects, filesToAffect } from "../../../morph";
+import { effects, filesToAffect, standaloneEffects } from "../../../morph";
 import { AngularTypeNames } from "../../types/types";
+import { EditFileEffect } from '../../../morph/interfaces/morph.interface';
 
 describe('exportComponentFile', () => {
   afterEach(() => {
@@ -43,4 +44,26 @@ describe('closestIndexFileToImportTo', () => {
     const fileToModify = filesToAffect(mockFilePath, fileTree, mockParameter, 'angular');
     expect(fileToModify).toEqual(['path/to/another/index.ts']);
   });
-})
+});
+
+describe('standaloneComponentEffects', () => {
+  it('should trigger standalone component effects', () => {
+    const programmingLanguage = 'angular';
+    const mockParameter = {
+      type: AngularTypeNames.StandaloneComponent
+    } as any;
+    const mockFileEffects: EditFileEffect[] = [{
+      filePath: 'path/to/another/index.ts',
+      originFilePath: 'path/to/another/src/hello.component.ts',
+      content: ``
+    }];
+    const result = standaloneEffects(programmingLanguage, mockParameter, mockFileEffects);
+    const indexContent = `export * from "./src/hello.component";
+`;
+    expect(result).toEqual([{
+      content: indexContent,
+      originFilePath: "path/to/another/src/hello.component.ts",
+      filePath: 'path/to/another/index.ts'
+    }]);
+  });
+});

--- a/src/rz/angular/effects/standalone-component/standlone-component.spec.ts
+++ b/src/rz/angular/effects/standalone-component/standlone-component.spec.ts
@@ -1,6 +1,6 @@
 import { TemplateInputParameter } from './../../../utils/interfaces/template-parameters';
 import { writeFileSync, readFileSync } from 'fs';
-import { effects } from "../../../morph";
+import { effects, filesToAffect } from "../../../morph";
 import { AngularTypeNames } from "../../types/types";
 
 describe('exportComponentFile', () => {
@@ -25,3 +25,22 @@ describe('exportComponentFile', () => {
     expect(result).toEqual(expected);
   });
 });
+
+describe('closestIndexFileToImportTo', () => {
+  it('should choose closest index file', () => {
+    const mockFilePath = 'path/to/another/src/hello.component.ts';
+    const mockParameter = {
+      optionalTypes: {},
+      type: AngularTypeNames.StandaloneComponent
+    } as any;
+    
+    const fileTree = [
+      "path/to/another/src",
+      "path/to/another/src/hello.component.ts",
+      "path/to/another/index.ts",
+      "path/to/another"
+    ];
+    const fileToModify = filesToAffect(mockFilePath, fileTree, mockParameter, 'angular');
+    expect(fileToModify).toEqual(['path/to/another/index.ts']);
+  });
+})

--- a/src/rz/utils/find-closest-file/find-closest-file.spec.ts
+++ b/src/rz/utils/find-closest-file/find-closest-file.spec.ts
@@ -1,5 +1,0 @@
-describe('findCloseFile', () => {
-  it('should find the close file using origin file path and file tree', () => {
-    
-  });  
-});

--- a/src/rz/utils/find-closest-file/find-closest-file.spec.ts
+++ b/src/rz/utils/find-closest-file/find-closest-file.spec.ts
@@ -1,0 +1,5 @@
+describe('findCloseFile', () => {
+  it('should find the close file using origin file path and file tree', () => {
+    
+  });  
+});

--- a/src/rz/utils/find-closest-file/find-closest-file.ts
+++ b/src/rz/utils/find-closest-file/find-closest-file.ts
@@ -1,0 +1,36 @@
+import { minimatch } from 'minimatch';
+
+export function getFileViaMatch(paths: string[], globPattern: string): any {
+  for (const item of paths) {
+    if (minimatch(item, globPattern)) {
+      return item;
+    }
+  }
+  return undefined;
+}
+  
+export function findClosestFileUsingPaths(filePathWithName: string, paths: string[], fileNameToFind = 'index.ts'): string[] {
+  let currentDir = filePathWithName;
+  while (currentDir.length > 0) {
+    const modulePath = currentDir + `/${fileNameToFind}`;
+    const moduleFile = getFileViaMatch(paths, modulePath);
+    if(moduleFile) {
+      return [moduleFile];
+    }
+    currentDir = currentDir.substring(0, currentDir.lastIndexOf("/"));
+  } 
+  return [];
+}
+
+export function findClosestFileMatchUsingPaths(filePathWithName: string, paths: string[], fileNameToFind = 'index.ts'): string[] {
+  let currentDir = filePathWithName;
+  while (currentDir.length > 0) {
+    const modulePath = currentDir + `/*.${fileNameToFind}`;
+    const moduleFile = getFileViaMatch(paths, modulePath);
+    if(moduleFile) {
+      return [moduleFile];
+    }
+    currentDir = currentDir.substring(0, currentDir.lastIndexOf("/"));
+  } 
+  return [];
+}

--- a/src/rz/utils/find-module-file/find-module-file.ts
+++ b/src/rz/utils/find-module-file/find-module-file.ts
@@ -14,7 +14,7 @@ export function findClosestModuleFile(path: string, fileNameToFind = 'module.ts'
     return "";
 }
 
-function getModuleFile(paths: string[], globPattern: string) {
+export function getFileViaMatch(paths: string[], globPattern: string): any {
   for (const item of paths) {
     if (minimatch(item, globPattern)) {
       return item;
@@ -27,7 +27,7 @@ export function findClosestModuleFileUsingPaths(filePathWithName: string, paths:
     let currentDir = filePathWithName;
     while (currentDir.length > 0) {
       const modulePath = currentDir + `/*.${fileNameToFind}`;
-      const moduleFile = getModuleFile(paths, modulePath);
+      const moduleFile = getFileViaMatch(paths, modulePath);
       if(moduleFile) {
         return [moduleFile];
       }


### PR DESCRIPTION
1. Creates re-usable functionality for file to effects. Should be pretty seamless/intuitive moving forward. 
2. Wires up functionality for standalone effects if it's a standalone component