### PR TITLE
Zeta 6939 optional classname for add property html

### DIFF
--- a/src/rz/angular/add-property-to-html-tag/add-property-to-html-tag.spec.ts
+++ b/src/rz/angular/add-property-to-html-tag/add-property-to-html-tag.spec.ts
@@ -58,7 +58,7 @@ describe('addPropertyToHtmlTag', () => {
       const expected = `<div></div>
 <div class="Toolbar__Icons" *ngIf="authenticated"></div>
 
-  `;
+`;
     expect(result).toEqual(expected);
   });
 });

--- a/src/rz/angular/add-property-to-html-tag/add-property-to-html-tag.spec.ts
+++ b/src/rz/angular/add-property-to-html-tag/add-property-to-html-tag.spec.ts
@@ -57,7 +57,6 @@ describe('addPropertyToHtmlTag', () => {
       const result = morphCode(editInput);
       const expected = `<div></div>
 <div class="Toolbar__Icons" *ngIf="authenticated"></div>
-
 `;
     expect(result).toEqual(expected);
   });

--- a/src/rz/angular/add-property-to-html-tag/add-property-to-html-tag.spec.ts
+++ b/src/rz/angular/add-property-to-html-tag/add-property-to-html-tag.spec.ts
@@ -32,4 +32,33 @@ describe('addPropertyToHtmlTag', () => {
 `;
     expect(result).toEqual(expected);
   });
+
+  it('should add a property to an html tag and use the class name to determine which element', () => {
+      const fileToBeAddedTo = `<div></div>
+<div class="Toolbar__Icons"></div>
+`;
+      const codeBlock = '{"*ngIf": "authenticated"}';
+  
+      const insertIntoHtmlTag: EditHtmlFile = {
+         nodeType: 'addPropertyToHtmlTag',
+         codeBlock: codeBlock,
+         tagNameToInsertInto: 'div',
+         className: 'Toolbar__Icons'
+      };
+  
+      const editInput = {
+        fileType: 'html',
+        fileToBeAddedTo: fileToBeAddedTo,
+        edits: [
+          insertIntoHtmlTag
+        ]
+      };
+  
+      const result = morphCode(editInput);
+      const expected = `<div></div>
+<div class="Toolbar__Icons" *ngIf="authenticated"></div>
+
+  `;
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/rz/angular/add-property-to-html-tag/add-property-to-html-tag.ts
+++ b/src/rz/angular/add-property-to-html-tag/add-property-to-html-tag.ts
@@ -9,12 +9,14 @@ export function addPropertyToHtmlTag(editFile: EditHtmlFile, fileToBeModified: a
   let firstMatchFound = false;
   visit(fileToBeModified, { type: 'element', tagName: editFile.tagNameToInsertInto }, (node: any, index) => {
     // Check if the tag is the one you want to modify
-    if (!firstMatchFound && node.tagName === editFile.tagNameToInsertInto) {
-      node.properties = {
-        ...(node.properties || {}),
-        ...codeBlock
-      };
-      firstMatchFound = true;
+    if(!editFile.className || editFile.className === '' || node.properties.className?.includes(editFile.className)) {
+      if (!firstMatchFound && node.tagName === editFile.tagNameToInsertInto) {
+        node.properties = {
+          ...(node.properties || {}),
+          ...codeBlock
+        };
+        firstMatchFound = true;
+      }
     }
   });
   


### PR DESCRIPTION
Adds the ability to use an optional className to determine which property to add to HTML

Now can have two divs 

```
<div></div>
<div class="Toolbar__Icons"></div>
````

but add the property to Toolbar__Icons div via targeting class name